### PR TITLE
Variable metric logging for classification

### DIFF
--- a/code/base_class/method.py
+++ b/code/base_class/method.py
@@ -19,6 +19,11 @@ class method:
     """
     MethodModule: Abstract Class
     Entries: method_name: the name of the MethodModule
+            batch_metrics (Optional[dict]): see method_notifier.py to see what are the allowable types of metrics
+                to pass into this dict
+            notification_manager (Optional[MethodNotifier]): this pings our experiment handler with information
+                pertinent to each epoch's training. Through this we are able to log information.
+
              method_description: the textual description of the MethodModule
 
              method_start_time: start running time of MethodModule
@@ -33,6 +38,8 @@ class method:
 
     data = None
     notification_manager: Optional[MethodNotifier]
+
+    batch_metrics: Optional[dict]
     method_start_time = None
     method_stop_time = None
     method_running_time = None
@@ -40,10 +47,16 @@ class method:
     method_testing_time = None
 
     # initialization function
-    def __init__(self, config: methodConfig, manager: Optional[MethodNotifier] = None):
+    def __init__(
+        self,
+        config: methodConfig,
+        manager: Optional[MethodNotifier] = None,
+        metrics: Optional[dict] = None,
+    ):
         self.method_name = config["name"]
         self.method_description = config["description"]
         self.notification_manager = manager
+        self.batch_metrics = metrics
 
     # running function
     @abc.abstractmethod

--- a/code/lib/comet_listeners.py
+++ b/code/lib/comet_listeners.py
@@ -27,9 +27,10 @@ class CometMethodHandler(MLEventListener):
 
         with self.__experiment.test():
 
-            self.__experiment.log_metrics(
-                {"accuracy": data.accuracy, "loss": data.loss}, step=self.__step, epoch=data.epoch
-            )
+            data_report = {k: v for k, v in data.dict().items() if k not in {"epoch"}}
+
+            self.__experiment.log_metrics(data_report, step=self.__step, epoch=data.epoch)
+
             self.__step = self.__step + 1
 
 

--- a/code/lib/notifier/__init__.py
+++ b/code/lib/notifier/__init__.py
@@ -8,6 +8,7 @@ from code.lib.notifier.evaluate_notifier import (
     EvaluateNotifier,
 )
 from code.lib.notifier.method_notifier import (
+    ClassificationNotification,
     MethodNotification,
     MethodNotifier,
 )

--- a/code/lib/notifier/method_notifier.py
+++ b/code/lib/notifier/method_notifier.py
@@ -1,16 +1,49 @@
 from code.base_class.notifier import MLEventNotifier, MLEventType
-from dataclasses import dataclass
-
-import torch
+from dataclasses import asdict, dataclass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MethodNotification:
-    y_true: torch.Tensor
-    y_pred: torch.Tensor
+    """
+        This subclass can be extended to support a flexable
+        collection of metrics into our experiment handlers. These
+        metrics measure statistics about our model's performance
+        on a given batch.
+
+    Args:
+        epoch (int): the epoch a metric is measured at
+        loss (int): the current loss of our epoch
+    """
+
     epoch: int
-    accuracy: float
     loss: float
+
+    def dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ClassificationNotification(MethodNotification):
+    """
+        This is a specialization of our method notifier for
+        classification.
+
+        In classification tasks, we are interested in measuring
+        the metrics associated with accuracy, f1, precision, as
+        well as recall.
+
+    Args:
+        accuracy (float): _description_
+        f1 (float): _description_
+        precision (float): _description_
+        recall (float): _description_
+
+    """
+
+    accuracy: float
+    f1: float
+    precision: float
+    recall: float
 
 
 class MethodNotifier(MLEventNotifier):

--- a/code/stage_1_code/Method_SVM.py
+++ b/code/stage_1_code/Method_SVM.py
@@ -7,6 +7,7 @@ Concrete MethodModule class for a specific learning MethodModule
 
 from code.base_class.method import method, methodConfig
 from code.lib.notifier import MethodNotifier
+from typing import Optional
 
 from sklearn import svm  # type: ignore
 
@@ -19,7 +20,7 @@ class Method_SVM(method):
     c = None
     data = None
 
-    def __init__(self, config: methodConfigSVM, manager: MethodNotifier):
+    def __init__(self, config: methodConfigSVM, manager: Optional[MethodNotifier]):
         super().__init__(config, manager)
         self.c = config["c"]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -734,6 +734,18 @@ setuptools = "*"
 wheel = "*"
 
 [[package]]
+name = "packaging"
+version = "23.0"
+description = "Core utilities for Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
+    {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+]
+
+[[package]]
 name = "pathspec"
 version = "0.11.0"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -1278,6 +1290,34 @@ typing-extensions = "*"
 opt-einsum = ["opt-einsum (>=3.3)"]
 
 [[package]]
+name = "torchmetrics"
+version = "0.11.1"
+description = "PyTorch native Metrics"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "torchmetrics-0.11.1-py3-none-any.whl", hash = "sha256:9987d7c21b081cceef246a72be1ce25bf29c842764f59dda54f59e3b4cd1970b"},
+    {file = "torchmetrics-0.11.1.tar.gz", hash = "sha256:de2e9feb3316f798ab08b318302ff04e764f47e691f0847f780044279fa176ca"},
+]
+
+[package.dependencies]
+numpy = ">=1.17.2"
+packaging = "*"
+torch = ">=1.8.1"
+
+[package.extras]
+all = ["lpips", "nltk (>=3.6)", "pycocotools", "pystoi", "pytorch-lightning (>=1.5)", "regex (>=2021.9.24)", "scipy", "torch-fidelity", "torchvision", "torchvision (>=0.8)", "tqdm (>=4.41.0)", "transformers (>=4.10.0)"]
+audio = ["pystoi"]
+detection = ["pycocotools", "torchvision (>=0.8)"]
+docs = ["docutils (>=0.16)", "myst-parser", "nbsphinx (>=0.8)", "pandoc (>=1.0)", "sphinx (>=4.0,<5.0)", "sphinx-autodoc-typehints (>=1.0)", "sphinx-copybutton (>=0.3)", "sphinx-paramlinks (>=0.5.1)", "sphinx-togglebutton (>=0.2)", "sphinxcontrib-fulltoc (>=1.0)", "sphinxcontrib-mockautodoc"]
+image = ["lpips", "scipy", "torch-fidelity", "torchvision"]
+integrate = ["pytorch-lightning (>=1.5)"]
+multimodal = ["transformers (>=4.10.0)"]
+test = ["bert-score (==0.3.10)", "check-manifest", "cloudpickle (>=1.3)", "coverage (>5.2)", "dython", "fast-bss-eval (>=0.1.0)", "fire", "huggingface-hub (<0.7)", "jiwer (>=2.3.0)", "kornia (>=0.6.7)", "mir-eval (>=0.6)", "mypy (==0.982)", "netcal", "pandas", "phmdoctest (>=1.1.1)", "pre-commit (>=1.0)", "psutil", "pycocotools", "pypesq (>1.2)", "pytest (>=6.0.0,<7.0.0)", "pytest-cov (>2.10)", "pytest-doctestplus (>=0.9.0)", "pytest-rerunfailures (>=10.0)", "pytest-timeout", "pytorch-msssim (==0.2.1)", "requests", "rouge-score (>=0.0.4)", "sacrebleu (>=2.0.0)", "scikit-image (>0.17.1)", "scikit-learn (>1.0,<1.1.1)", "scipy", "torch-complex", "transformers (>4.4.0)", "types-PyYAML", "types-emoji", "types-protobuf", "types-requests", "types-setuptools", "types-six", "types-tabulate"]
+text = ["nltk (>=3.6)", "regex (>=2021.9.24)", "tqdm (>=4.41.0)"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1448,4 +1488,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a548cbe7d7ed2d97188ec4cf323c46d9dddd3dac1b568e365bb50571658aa354"
+content-hash = "62bacb2099c83afd0e9e16a7e17910df680e8b34b28e19f059e85214717f5cb4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ python = "^3.9"
 comet-ml = ">=3.31.22"
 torch = ">=1.13.1"
 scikit-learn = ">=1.2.0"
+torchmetrics = "^0.11.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/script/stage_1_script/script_mlp.py
+++ b/script/stage_1_script/script_mlp.py
@@ -21,6 +21,12 @@ from code.stage_1_code.Setting_Train_Test_Split import Setting_Train_Test_Split
 
 import numpy as np
 import torch
+from torchmetrics.classification import (
+    BinaryAccuracy,
+    BinaryF1Score,
+    BinaryPrecision,
+    BinaryRecall,
+)
 
 # ---- Multi-Layer Perceptron script ----
 if 1:
@@ -82,7 +88,14 @@ if 1:
 
     m_notifier = MethodNotifier()
     m_notifier.subscribe(experiment_tracker.method_listener, MLEventType("method"))
-    method_obj = Method_MLP(m_config, m_notifier)
+    batch_metrics = {
+        "accuracy": BinaryAccuracy(),
+        "f1": BinaryF1Score(),
+        "precision": BinaryPrecision(),
+        "recall": BinaryRecall(),
+    }
+
+    method_obj = Method_MLP(m_config, m_notifier, batch_metrics)
 
     r_notifier = ResultNotifier()
     r_notifier.subscribe(experiment_tracker.result_listener, MLEventType("save"))
@@ -94,13 +107,13 @@ if 1:
 
     e_notifier = EvaluateNotifier()
     e_notifier.subscribe(experiment_tracker.evaluation_listener, MLEventType("evaluate"))
-    evaluate_obj = Evaluate_Accuracy(e_config, e_notifier)
+    final_evaluation = Evaluate_Accuracy(e_config, e_notifier)
 
     # ------------------------------------------------------
 
     # ---- running section ---------------------------------
     print("************ Start ************")
-    setting_obj.prepare(data_obj, method_obj, result_obj, evaluate_obj)
+    setting_obj.prepare(data_obj, method_obj, result_obj, final_evaluation)
     setting_obj.print_setup_summary()
     mean_score, std_score = setting_obj.load_run_save_evaluate()
     print("************ Overall Performance ************")


### PR DESCRIPTION
Closes #9.

Previously we were only capturing accuracy statistics for a given batch, but now we are able to extend to a variable number of metrics for classification specifically. In a future implementation, this will be even more generalized, to support most of the `torch_metrics` functions. Additionally, it would be desirable to depreciate the evaluate classes. For now, this should be suffice for Stage 2. 

For example, here is a screenshot of the Comet UI. It shows not only accuracy, but also precision, recall, and F1 score. 

<img width="1446" alt="image" src="https://user-images.githubusercontent.com/43937630/216447028-61fa05d2-674a-48b3-a561-f2e8228497c7.png">
