### PR TITLE
feat: Now saves model artifacts to results and Comet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/code/base_class/result.py
+++ b/code/base_class/result.py
@@ -10,6 +10,8 @@ import abc
 from code.lib.notifier import ResultNotifier
 from typing import Optional, TypedDict
 
+from torch import nn
+
 
 class resultConfig(TypedDict):
     name: str
@@ -35,14 +37,23 @@ class result:
     _manager: Optional[ResultNotifier]
     fold_count: Optional[int]
 
+    # contains a reference to the model, necessary for properly notifying the handlers to save artifacts
+    parent_model: Optional[nn.Module]
+
     # initialization function
-    def __init__(self, config: resultConfig, manager: Optional[ResultNotifier] = None):
+    def __init__(
+        self,
+        config: resultConfig,
+        manager: Optional[ResultNotifier] = None,
+        parent_model: Optional[nn.Module] = None,
+    ):
 
         self.result_name = config["name"]
         self.result_description = config["description"]
         self.result_destination_folder_path = config["destination_folder_path"]
         self.result_destination_file_name = config["destination_file_name"]
         self._manager = manager
+        self.parent_model = parent_model
 
     def get_data(self, _d) -> None:
         self.data = _d

--- a/code/lib/comet_listeners.py
+++ b/code/lib/comet_listeners.py
@@ -58,6 +58,9 @@ class CometResultHandler(MLEventListener):
 
     def update(self, data: ResultNotification) -> None:
         self.__experiment.log_parameter("filename", data.filename)
+        # Maybe do model saving here?
+        if data.state_dict is not None:
+            self.__experiment.log_model("Model_Artifacts", data.artifact_filename)
 
 
 class CometSettingHandler(MLEventListener):

--- a/code/lib/notifier/result_notifier.py
+++ b/code/lib/notifier/result_notifier.py
@@ -1,6 +1,7 @@
 from code.base_class.notifier import MLEventNotifier, MLEventType
+from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 import torch
 
@@ -14,6 +15,8 @@ class Data(TypedDict):
 class ResultNotification:
     data: Data
     filename: str
+    artifact_filename: str
+    state_dict: Optional[OrderedDict]
 
 
 class ResultNotifier(MLEventNotifier):

--- a/code/stage_1_code/Result_Loader.py
+++ b/code/stage_1_code/Result_Loader.py
@@ -16,11 +16,15 @@ class Result_Loader(result):
     def load(self) -> None:
         print("loading results...")
         filename = f"{self.result_destination_folder_path}{self.result_destination_file_name}_{str(self.fold_count)}"
+        artifact_filename = f"{self.result_destination_folder_path}{self.result_destination_file_name}_{str(self.fold_count)}_artifacts"
 
         with open(filename, "rb") as f:
             self.data = pickle.load(f)
             if self._manager is not None:
-                self._manager.notify(MLEventType("load"), ResultNotification(self.data, filename))
+                self._manager.notify(
+                    MLEventType("load"),
+                    ResultNotification(self.data, filename, artifact_filename, None),
+                )
 
     def save(self) -> None:
         pass

--- a/code/stage_1_code/Result_Saver.py
+++ b/code/stage_1_code/Result_Saver.py
@@ -9,6 +9,8 @@ import pickle
 from code.base_class.result import result
 from code.lib.notifier import MLEventType, ResultNotification
 
+import torch
+
 
 class Result_Saver(result):
     fold_count = None
@@ -16,11 +18,25 @@ class Result_Saver(result):
     def save(self):
         print("saving results...")
         filename = f"{self.result_destination_folder_path}{self.result_destination_file_name}_{str(self.fold_count)}"
+        artifact_filename = f"{self.result_destination_folder_path}{self.result_destination_file_name}_{str(self.fold_count)}_artifacts"
+
+        # save artifacts if parent model was given
+        if self.parent_model is not None:
+            torch.save(self.parent_model.state_dict(), artifact_filename)
 
         with open(filename, "wb") as f:
             pickle.dump(self.data, f)
             if self._manager is not None:
-                self._manager.notify(MLEventType("save"), ResultNotification(self.data, filename))
+                # only passes parent_model.state_dict() if parent_model exists
+                self._manager.notify(
+                    MLEventType("save"),
+                    ResultNotification(
+                        self.data,
+                        filename,
+                        artifact_filename,
+                        self.parent_model.state_dict() if self.parent_model is not None else None,
+                    ),
+                )
 
     def load(self) -> None:
         pass

--- a/code/tests/test_artifacts.py
+++ b/code/tests/test_artifacts.py
@@ -1,0 +1,91 @@
+import os
+import unittest
+from code.base_class.method import methodConfig
+from code.base_class.result import resultConfig
+from code.stage_1_code.Method_MLP import Method_MLP
+from code.stage_1_code.Result_Saver import Result_Saver
+from collections import OrderedDict
+from unittest.mock import Mock
+
+import torch
+from torch import tensor
+
+"""
+    To run this class, perform `python -m code.tests.test_example`
+    in the command line.
+"""
+
+
+class TestArtifacts(unittest.TestCase):
+    def test_artifacts(self):
+        r_config = resultConfig(
+            {
+                "name": "test",
+                "description": "...data description...",
+                "destination_folder_path": "code/tests/",
+                "destination_file_name": "testartifacts",
+            }
+        )
+        m_config = methodConfig(
+            {
+                "name": "test-method",
+                "description": "This is a test",
+            }
+        )
+
+        method_obj = Mock()
+        testdict = OrderedDict(
+            [
+                (
+                    "fc_layer_1.weight",
+                    tensor(
+                        [
+                            [0.7172, 0.1651, -0.0167, 0.0633],
+                            [0.2136, 0.1190, -0.0575, -0.4042],
+                            [0.1142, -0.4427, 0.0657, 0.0332],
+                            [-0.6775, 0.1094, 0.1887, 0.1240],
+                        ]
+                    ),
+                ),
+                ("fc_layer_1.bias", tensor([0.0213, -0.2950, -0.1922, 0.6772])),
+                (
+                    "fc_layer_2.weight",
+                    tensor(
+                        [[-1.1560, -0.0340, -0.0396, 0.9381], [0.6188, 0.1317, -0.0240, -0.8634]]
+                    ),
+                ),
+                ("fc_layer_2.bias", tensor([-0.1579, -0.3684])),
+            ]
+        )
+
+        method_obj.state_dict.return_value = testdict
+
+        result_obj = Result_Saver(r_config, None, method_obj)
+        result_obj.get_data([1, 2, 3, 4, 5])
+
+        result_obj.save()
+
+        new_model = Method_MLP(m_config, None)
+        new_model.load_state_dict(
+            torch.load(
+                f"{result_obj.result_destination_folder_path}{result_obj.result_destination_file_name}_{str(result_obj.fold_count)}_artifacts"
+            )
+        )
+        if os.path.exists(
+            f"{result_obj.result_destination_folder_path}{result_obj.result_destination_file_name}_{str(result_obj.fold_count)}_artifacts"
+        ):
+            os.remove(
+                f"{result_obj.result_destination_folder_path}{result_obj.result_destination_file_name}_{str(result_obj.fold_count)}_artifacts"
+            )
+        if os.path.exists(
+            f"{result_obj.result_destination_folder_path}{result_obj.result_destination_file_name}_{str(result_obj.fold_count)}"
+        ):
+            os.remove(
+                f"{result_obj.result_destination_folder_path}{result_obj.result_destination_file_name}_{str(result_obj.fold_count)}"
+            )
+        for a, b in zip(new_model.state_dict(), testdict):
+            assert torch.equal(new_model.state_dict()[a], testdict[b])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -839,14 +839,14 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-
 
 [[package]]
 name = "pre-commit"
-version = "3.0.2"
+version = "3.0.3"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pre_commit-3.0.2-py2.py3-none-any.whl", hash = "sha256:f448d5224c70e196a6c6f87961d2333dfdc49988ebbf660477f9efe991c03597"},
-    {file = "pre_commit-3.0.2.tar.gz", hash = "sha256:aa97fa71e7ab48225538e1e91a6b26e483029e6de64824f04760c32557bc91d7"},
+    {file = "pre_commit-3.0.3-py2.py3-none-any.whl", hash = "sha256:83e2e8cc5cbb3691cff9474494816918d865120768aa36c9eda6185126667d21"},
+    {file = "pre_commit-3.0.3.tar.gz", hash = "sha256:4187e74fda38f0f700256fb2f757774385503b04292047d0899fc913207f314b"},
 ]
 
 [package.dependencies]
@@ -1206,14 +1206,14 @@ tornado = ["tornado (>=5)"]
 
 [[package]]
 name = "setuptools"
-version = "67.0.0"
+version = "67.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.0.0-py3-none-any.whl", hash = "sha256:9d790961ba6219e9ff7d9557622d2fe136816a264dd01d5997cfc057d804853d"},
-    {file = "setuptools-67.0.0.tar.gz", hash = "sha256:883131c5b6efa70b9101c7ef30b2b7b780a4283d5fc1616383cdf22c83cbefe6"},
+    {file = "setuptools-67.1.0-py3-none-any.whl", hash = "sha256:a7687c12b444eaac951ea87a9627c4f904ac757e7abdc5aac32833234af90378"},
+    {file = "setuptools-67.1.0.tar.gz", hash = "sha256:e261cdf010c11a41cb5cb5f1bf3338a7433832029f559a6a7614bd42a967c300"},
 ]
 
 [package.extras]

--- a/script/stage_1_script/script_mlp.py
+++ b/script/stage_1_script/script_mlp.py
@@ -99,7 +99,7 @@ if 1:
 
     r_notifier = ResultNotifier()
     r_notifier.subscribe(experiment_tracker.result_listener, MLEventType("save"))
-    result_obj = Result_Saver(r_config, r_notifier)
+    result_obj = Result_Saver(r_config, r_notifier, method_obj)
 
     s_notifier = SettingNotifier()
     s_notifier.subscribe(experiment_tracker.setting_listener, MLEventType("setting"))
@@ -110,7 +110,6 @@ if 1:
     final_evaluation = Evaluate_Accuracy(e_config, e_notifier)
 
     # ------------------------------------------------------
-
     # ---- running section ---------------------------------
     print("************ Start ************")
     setting_obj.prepare(data_obj, method_obj, result_obj, final_evaluation)
@@ -120,3 +119,4 @@ if 1:
     print("MLP Accuracy: " + str(mean_score) + " +/- " + str(std_score))
     print("************ Finish ************")
     # ------------------------------------------------------
+    print(method_obj.state_dict())


### PR DESCRIPTION
I added onto the code that saves the results of our experiments locally so that our model weights are also saved. These weights are also uploaded to Comet, at which point we can register our highest-performing models and deploy them again later. The notification system for saving the Results now contains a reference to the model object so that these values can be accessed, which has slightly changed the initialization function for the Result class. A new unit test was also added to demonstrate these features. 
Places for iteration and/or improvement: currently there is no way programmatically to register and deploy our models again. The registering is fairly easy to do through Comet's web interface, but we should write a script to deploy an existing model and run it through a dataset in order to replicate the results of past experiments. Additionally the experiment results and model weights are currently saved as separate files, and it may be possible to bundle them together with Pythons pickle library to be a bit cleaner. 